### PR TITLE
Removed unused @babel/runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
 	"author": "Brian Alexis Michel <brrianalexis.dev@gmail.com> (https://github.com/brrianalexis)",
 	"license": "MIT",
 	"dependencies": {
-		"@babel/runtime": "^7.20.6",
 		"aria-query": "^5.1.3",
 		"chalk": "^4.1.0",
 		"css": "^3.0.0",


### PR DESCRIPTION


**What**:

Removed unused `@babel/runtime`. [Related](https://github.com/testing-library/jasmine-dom/issues/76#issuecomment-1359946717).

**Why**:

Because it's unused

**How**:

removed with npm from `package.json`

**Checklist**:

- [x] Documentation (Not needed)
- [x] Tests
- [x] Updated Type Definitions (Not needed)
- [x] Ready to be merged


