### PR TITLE
fix: add missing package dom-accessibility-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
 		"chalk": "^4.1.0",
 		"css": "^3.0.0",
 		"css.escape": "^1.5.1",
+		"dom-accessibility-api": "^0.5.16",
 		"lodash": "^4.17.21"
 	},
 	"devDependencies": {


### PR DESCRIPTION
**What**:

Fixing #80 
Missing `dom-accessibility-api` dependecy

**Why**:

Used by `toHaveAccessibleName`

**How**:

Installed dependency. It seems got hoisted by other dependencies 

**Checklist**:

- [ ] Documentation
- [ ] Tests
- [ ] Updated Type Definitions
- [x] Ready to be merged
