### PR TITLE
docs: update code examples and add angular usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,7 @@ yarn add --dev @testing-library/jasmine-dom
 
 ### With JavaScript
 
-You should have a directory for helpers specified inside the helpers array in your `jasmine.json` file.
-Example:
+You should have a directory for helpers specified inside the `/helpers` array in your `jasmine.json` file, for example:
 
 ```json
 {
@@ -116,7 +115,7 @@ Example:
 }
 ```
 
-Make a new file inside that directory, import @testing-library/jasmine-dom and add the matchers like so:
+Make a new file inside that directory, import `@testing-library/jasmine-dom` and add the matchers like so:
 
 ```javascript
 import JasmineDOM from '@testing-library/jasmine-dom';
@@ -128,15 +127,13 @@ beforeAll(() => {
 
 ### With TypeScript
 
-Install the type definitions:
+Install the type definitions with:
 
 ```
 npm install --save-dev @types/testing-library__jasmine-dom
 ```
 
-Add `"@testing-library/jasmine-dom"` to `types` in the tests `tsconfig` (e.g. `tsconfig.spec.json` in an Angular project).
-
-Example:
+Add `"@testing-library/jasmine-dom"` to `/compilerOptions/types` in the tests `tsconfig`, for example:
 
 ```json
 {
@@ -146,15 +143,7 @@ Example:
 }
 ```
 
-In your tests setup file, (`test.ts` in an Angular project) import jasmine-dom and add the matchers like so:
-
-```typescript
-import JasmineDOM from '@testing-library/jasmine-dom';
-
-beforeAll(() => {
-	jasmine.addMatchers(JasmineDOM);
-});
-```
+Follow the [JavaScript instructions](#with-javascript) to add the matchers.
 
 ## Matchers
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Make a new file inside that directory, import @testing-library/jasmine-dom and a
 import JasmineDOM from '@testing-library/jasmine-dom';
 
 beforeAll(() => {
-	jasmine.getEnv().addMatchers(JasmineDOM);
+	jasmine.addMatchers(JasmineDOM);
 });
 ```
 
@@ -143,10 +143,10 @@ Example:
 In your tests setup file, (`test.ts` in an Angular project) import jasmine-dom and add the matchers like so:
 
 ```typescript
-import JasmineDOM from '@testing-library/jasmine-dom/dist';
+import JasmineDOM from '@testing-library/jasmine-dom';
 
 beforeAll(() => {
-	jasmine.getEnv().addMatchers(JasmineDOM);
+	jasmine.addMatchers(JasmineDOM);
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,54 @@ Add `"@testing-library/jasmine-dom"` to `/compilerOptions/types` in the tests `t
 
 Follow the [JavaScript instructions](#with-javascript) to add the matchers.
 
+
+### With Angular
+
+Follow the [TypeScript instructions](#with-typescript) to install the type definitions, making sure to include the types in `tsconfig.spec.json`, the configuration file used for the test environment.
+
+Add the matchers in the test setup file, which is typically located in `src/test.ts`:
+
+```ts
+import { getTestBed } from '@angular/core/testing';
+import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+import JasmineDOM from '@testing-library/jasmine-dom';
+
+beforeAll(() => {
+	jasmine.addMatchers(JasmineDOM);
+});
+
+getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {});
+```
+
+If your project was created with Angular 15 or later, you will not have a test setup file, so you will need to create one. Create a `test.ts` file in `src` with the code shown in the previous step, and then add the path to it in `angular.json` in `/projects/<your-project>/architect/test/options/main`:
+
+```json
+{
+	"projects": {
+		"myProject": {
+			"architect": {
+				"test": {
+					"builder": "@angular-devkit/build-angular:karma",
+					"options": {
+						"polyfills": ["zone.js", "zone.js/testing"],
+						"tsConfig": "tsconfig.spec.json",
+						"assets": [
+							{
+								"glob": "**/*",
+								"input": "public"
+							}
+						],
+						"main": "src/test.ts",
+						"styles": ["src/styles.css"],
+						"scripts": []
+					}
+				}
+			}
+		}
+	}
+}
+```
+
 ## Matchers
 
 This library is meant to be a Jasmine version of `@testing-library/jest-dom` library. As such, it provides the same set of matchers and the same functionality for each one, with a couple of minor diferences:

--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ beforeAll(() => {
 
 ### With TypeScript
 
+Install the type definitions:
+
+```
+npm install --save-dev @types/testing-library__jasmine-dom
+```
+
 Add `"@testing-library/jasmine-dom"` to `types` in the tests `tsconfig` (e.g. `tsconfig.spec.json` in an Angular project).
 
 Example:


### PR DESCRIPTION
**What**:

I have updated the `README.md` to:

- Update code examples: `.addMatchers()` can no longer be called from `jasmine.getEnv()`, and `/dist` is not needed in `import JasmineDOM from '@testing-library/jasmine-dom/dist';`
- Explain how to install the type definitions for TypeScript.
- Add Angular usage section.

**Why**:

- The code examples are outdated, `jasmine.getEnv().addMatchers` no longer works.
- The TypeScript section explains how to include the type definitions, but it does not mention that the type definitions need to be installed first.
- Angular projects created with Angular 15 or later do not include a test setup file, so I think it deserves its own section to explain how to create one.

**How**:

N/A

**Checklist**:

- [x] Documentation
- [x] Tests (N/A)
- [x] Updated Type Definitions
- [x] Ready to be merged

